### PR TITLE
Add root table

### DIFF
--- a/src/HashArrayMappedTries.jl
+++ b/src/HashArrayMappedTries.jl
@@ -55,13 +55,11 @@ Node{K, V}() where {K, V} = Node(
 const Layer{K,V} = Vector{Union{Node{K, V}, Leaf{K, V}}}
 mutable struct HAMT{K,V}
     const layer::Layer{K,V}
-    t::Int # size = 2^t and t = k*BITS_PER_LEVEL
+    t::Int # size = 2^t
     function HAMT(layer::Layer{K,V}) where {K,V}
         N = length(data)
         @assert ispow2(N)
         t = trailing_zeros(N)
-        k = t ÷ BITS_PER_LEVEL
-        @assert t == k*BITS_PER_LEVEL
         return new(layer, t)
     end
 end
@@ -76,10 +74,10 @@ function resize!(hamt::HAMT{K,V})
             entry = hamt.layer[iL]
             if entry isa Leaf{K,V}
                 layer[i] = entry
-                i +=  # skip
+                i += ENTRY_COUNT  # skip
             else
                 node = entry::Node{K,T}
-                for j in 0:ENTRY_COUNT
+                for j in 0:(ENTRY_COUNT-1)
                     bI = BitmapIndex(j)
                     if isset(node, bI)
                         layer[i] = node.data[entry_index(node, bI)]


### PR DESCRIPTION
[Bagewell](https://lampwww.epfl.ch/papers/idealhashtrees.pdf) uses the notion of a resizable
root table to make access faster, see section 3.1 and 3.4.

The root table takes the first `t` bits of the hash for indexing into itself.
Root table sizes are `2^t`, when we resize the table we must use `t_new = t + NBITS_PER_LAYER`,
so that we essentially can flatten the whole first layer and don't require any
re-hashing. 

Bagwell Table 1 and Table 2  shows the performance of having a root table `HAMTC` vs not-having a root table `HAMTL`.
For search `HAMTC` outperforms `HAMTL` at 32K set size and for insertion 2048K. 

The difference in search is the strongest argument, but implementing root table complicates
the implementation quite a bit. It also may not be the best fit for persitent dictionaries,
since it will be less space efficient. We will need to duplicate the root table per persistent
operation.


